### PR TITLE
Adding strictly typed Events to libcompose

### DIFF
--- a/docker/service/service.go
+++ b/docker/service/service.go
@@ -339,12 +339,14 @@ func (s *Service) up(ctx context.Context, imageName string, create bool, options
 			return err
 		}
 
+		s.project.Notify(events.NewContainerStartStartEvent(s.name, c.Name()))
+
 		err = c.Start(ctx)
 
 		if err == nil {
-			s.project.Notify(events.ContainerStarted, s.name, map[string]string{
-				"name": c.Name(),
-			})
+			s.project.Notify(events.NewContainerStartDoneEvent(s.name, c.Name()))
+		} else {
+			s.project.Notify(events.NewContainerStartFailedEvent(s.name, c.Name(), err))
 		}
 
 		return err
@@ -683,8 +685,7 @@ func (s *Service) Events(ctx context.Context, evts chan events.ContainerEvent) e
 					attributes[attr] = event.Actor.Attributes[attr]
 				}
 				e := events.ContainerEvent{
-					Service:    service,
-					Event:      event.Action,
+					Event:      events.NewEvent(service, m.Action),
 					Type:       event.Type,
 					ID:         event.Actor.ID,
 					Time:       time.Unix(event.Time, 0),

--- a/docker/service/service.go
+++ b/docker/service/service.go
@@ -685,7 +685,7 @@ func (s *Service) Events(ctx context.Context, evts chan events.ContainerEvent) e
 					attributes[attr] = event.Actor.Attributes[attr]
 				}
 				e := events.ContainerEvent{
-					Event:      events.NewEvent(service, m.Action),
+					Event:      events.NewEvent(service, event.Action),
 					Type:       event.Type,
 					ID:         event.Actor.ID,
 					Time:       time.Unix(event.Time, 0),

--- a/docker/service/service_create.go
+++ b/docker/service/service_create.go
@@ -57,13 +57,14 @@ func (s *Service) createContainer(ctx context.Context, namer Namer, oldContainer
 
 	logrus.Debugf("Creating container %s %#v", containerName, configWrapper)
 	// FIXME(vdemeester): long-term will be container.Create(…)
+	s.project.Notify(events.NewContainerCreateStartEvent(s.name, containerName))
+
 	container, err := composecontainer.Create(ctx, client, containerName, configWrapper.Config, configWrapper.HostConfig, configWrapper.NetworkingConfig)
 	if err != nil {
+		s.project.Notify(events.NewContainerCreateFailedEvent(s.name, containerName, err))
 		return nil, err
 	}
-	s.project.Notify(events.ContainerCreated, s.name, map[string]string{
-		"name": containerName,
-	})
+	s.project.Notify(events.NewContainerCreateDoneEvent(s.name, containerName))
 	return container, nil
 }
 

--- a/project/events/events.go
+++ b/project/events/events.go
@@ -2,13 +2,133 @@
 package events
 
 import (
-	"fmt"
 	"time"
 )
 
+// Event holds project-wide event informations.
+type Event interface {
+	String() string
+	Service() string
+}
+
+// baseEvent contains the base data for all events
+type baseEvent struct {
+	Event       string `json:"event"`
+	ServiceName string `json:"service"`
+}
+
+// String returns a string representation of the event
+func (b *baseEvent) String() string {
+	return b.Event
+}
+
+// Service returns the service name for the event
+func (b *baseEvent) Service() string {
+	return b.ServiceName
+}
+
+// NewEvent creates a new Event which matches the Event interface
+func NewEvent(event, service string) Event {
+	return &baseEvent{
+		Event:       event,
+		ServiceName: service,
+	}
+}
+
+// EventFactory creates a new Event
+type EventFactory func(service string) Event
+
+// ErrorEventFactory creates a new Event for a specified service and error
+type ErrorEventFactory func(service string, err error) Event
+
+// EventWrapper provides a wrapper around EventFactories to allow
+// state dependent Event generation
+type EventWrapper interface {
+	Started(string) Event
+	Failed(string, error) Event
+	Done(string) Event
+	Action() string
+}
+
+type eventWrapper struct {
+	startedFactory EventFactory
+	failedFactory  ErrorEventFactory
+	doneFactory    EventFactory
+	action         string
+}
+
+// Started creates a new event using the provided EventFactory for
+// the 'started' condition
+func (wrapper *eventWrapper) Started(serviceName string) Event {
+	if wrapper.startedFactory != nil {
+		return wrapper.startedFactory(serviceName)
+	}
+	return nil
+}
+
+// Failed creates a new event using the provided eventFactory for
+// the 'failed' condition
+func (wrapper *eventWrapper) Failed(serviceName string, err error) Event {
+	if wrapper.failedFactory != nil {
+		return wrapper.failedFactory(serviceName, err)
+	}
+	return nil
+}
+
+// Done creates a new event using the provided eventFactory for
+// the 'done' condition
+func (wrapper *eventWrapper) Done(serviceName string) Event {
+	if wrapper.doneFactory != nil {
+		return wrapper.doneFactory(serviceName)
+	}
+	return nil
+}
+
+// Action returns the name of the action this wrapper is supporting
+func (wrapper *eventWrapper) Action() string {
+	return wrapper.action
+}
+
+// NewEventWrapper builds a wrapper around the provided EventFactories
+func NewEventWrapper(action string, started EventFactory, done EventFactory, failed ErrorEventFactory) EventWrapper {
+	return &eventWrapper{
+		startedFactory: started,
+		failedFactory:  failed,
+		doneFactory:    done,
+		action:         action,
+	}
+}
+
+// NewDummyEventWrapper returns an event wrapper which returns nil events
+func NewDummyEventWrapper(action string) EventWrapper {
+	return &dummyEventWrapper{
+		action: action,
+	}
+}
+
+type dummyEventWrapper struct {
+	action string
+}
+
+func (*dummyEventWrapper) Started(string) Event {
+	return nil
+}
+
+func (*dummyEventWrapper) Done(string) Event {
+	return nil
+}
+
+func (*dummyEventWrapper) Failed(string, error) Event {
+	return nil
+}
+
+func (w *dummyEventWrapper) Action() string {
+	return w.action
+}
+
 // Notifier defines the methods an event notifier should have.
 type Notifier interface {
-	Notify(eventType EventType, serviceName string, data map[string]string)
+	Notify(event Event)
 }
 
 // Emitter defines the methods an event emitter should have.
@@ -16,209 +136,1087 @@ type Emitter interface {
 	AddListener(c chan<- Event)
 }
 
-// Event holds project-wide event informations.
-type Event struct {
-	EventType   EventType
-	ServiceName string
-	Data        map[string]string
-}
-
 // ContainerEvent holds attributes of container events.
 type ContainerEvent struct {
-	Service    string            `json:"service"`
-	Event      string            `json:"event"`
+	Event
 	ID         string            `json:"id"`
 	Time       time.Time         `json:"time"`
 	Attributes map[string]string `json:"attributes"`
 	Type       string            `json:"type"`
 }
 
-// EventType defines a type of libcompose event.
-type EventType int
+// ServiceAdd represents a service being added to a project
+type ServiceAdd struct {
+	Event
+}
 
-// Definitions of libcompose events
-const (
-	NoEvent = EventType(iota)
-
-	ContainerCreated = EventType(iota)
-	ContainerStarted = EventType(iota)
-
-	ServiceAdd          = EventType(iota)
-	ServiceUpStart      = EventType(iota)
-	ServiceUpIgnored    = EventType(iota)
-	ServiceUp           = EventType(iota)
-	ServiceCreateStart  = EventType(iota)
-	ServiceCreate       = EventType(iota)
-	ServiceDeleteStart  = EventType(iota)
-	ServiceDelete       = EventType(iota)
-	ServiceDownStart    = EventType(iota)
-	ServiceDown         = EventType(iota)
-	ServiceRestartStart = EventType(iota)
-	ServiceRestart      = EventType(iota)
-	ServicePullStart    = EventType(iota)
-	ServicePull         = EventType(iota)
-	ServiceKillStart    = EventType(iota)
-	ServiceKill         = EventType(iota)
-	ServiceStartStart   = EventType(iota)
-	ServiceStart        = EventType(iota)
-	ServiceBuildStart   = EventType(iota)
-	ServiceBuild        = EventType(iota)
-	ServicePauseStart   = EventType(iota)
-	ServicePause        = EventType(iota)
-	ServiceUnpauseStart = EventType(iota)
-	ServiceUnpause      = EventType(iota)
-	ServiceStopStart    = EventType(iota)
-	ServiceStop         = EventType(iota)
-	ServiceRunStart     = EventType(iota)
-	ServiceRun          = EventType(iota)
-
-	VolumeAdd  = EventType(iota)
-	NetworkAdd = EventType(iota)
-
-	ProjectDownStart     = EventType(iota)
-	ProjectDownDone      = EventType(iota)
-	ProjectCreateStart   = EventType(iota)
-	ProjectCreateDone    = EventType(iota)
-	ProjectUpStart       = EventType(iota)
-	ProjectUpDone        = EventType(iota)
-	ProjectDeleteStart   = EventType(iota)
-	ProjectDeleteDone    = EventType(iota)
-	ProjectRestartStart  = EventType(iota)
-	ProjectRestartDone   = EventType(iota)
-	ProjectReload        = EventType(iota)
-	ProjectReloadTrigger = EventType(iota)
-	ProjectKillStart     = EventType(iota)
-	ProjectKillDone      = EventType(iota)
-	ProjectStartStart    = EventType(iota)
-	ProjectStartDone     = EventType(iota)
-	ProjectBuildStart    = EventType(iota)
-	ProjectBuildDone     = EventType(iota)
-	ProjectPauseStart    = EventType(iota)
-	ProjectPauseDone     = EventType(iota)
-	ProjectUnpauseStart  = EventType(iota)
-	ProjectUnpauseDone   = EventType(iota)
-	ProjectStopStart     = EventType(iota)
-	ProjectStopDone      = EventType(iota)
-)
-
-func (e EventType) String() string {
-	var m string
-	switch e {
-	case ContainerCreated:
-		m = "Created container"
-	case ContainerStarted:
-		m = "Started container"
-
-	case ServiceAdd:
-		m = "Adding"
-	case ServiceUpStart:
-		m = "Starting"
-	case ServiceUpIgnored:
-		m = "Ignoring"
-	case ServiceUp:
-		m = "Started"
-	case ServiceCreateStart:
-		m = "Creating"
-	case ServiceCreate:
-		m = "Created"
-	case ServiceDeleteStart:
-		m = "Deleting"
-	case ServiceDelete:
-		m = "Deleted"
-	case ServiceStopStart:
-		m = "Stopping"
-	case ServiceStop:
-		m = "Stopped"
-	case ServiceDownStart:
-		m = "Stopping"
-	case ServiceDown:
-		m = "Stopped"
-	case ServiceRestartStart:
-		m = "Restarting"
-	case ServiceRestart:
-		m = "Restarted"
-	case ServicePullStart:
-		m = "Pulling"
-	case ServicePull:
-		m = "Pulled"
-	case ServiceKillStart:
-		m = "Killing"
-	case ServiceKill:
-		m = "Killed"
-	case ServiceStartStart:
-		m = "Starting"
-	case ServiceStart:
-		m = "Started"
-	case ServiceBuildStart:
-		m = "Building"
-	case ServiceBuild:
-		m = "Built"
-	case ServiceRunStart:
-		m = "Executing"
-	case ServiceRun:
-		m = "Executed"
-	case ServicePauseStart:
-		m = "Pausing"
-	case ServicePause:
-		m = "Paused"
-	case ServiceUnpauseStart:
-		m = "Unpausing"
-	case ServiceUnpause:
-		m = "Unpaused"
-
-	case ProjectDownStart:
-		m = "Stopping project"
-	case ProjectDownDone:
-		m = "Project stopped"
-	case ProjectStopStart:
-		m = "Stopping project"
-	case ProjectStopDone:
-		m = "Project stopped"
-	case ProjectCreateStart:
-		m = "Creating project"
-	case ProjectCreateDone:
-		m = "Project created"
-	case ProjectUpStart:
-		m = "Starting project"
-	case ProjectUpDone:
-		m = "Project started"
-	case ProjectDeleteStart:
-		m = "Deleting project"
-	case ProjectDeleteDone:
-		m = "Project deleted"
-	case ProjectRestartStart:
-		m = "Restarting project"
-	case ProjectRestartDone:
-		m = "Project restarted"
-	case ProjectReload:
-		m = "Reloading project"
-	case ProjectReloadTrigger:
-		m = "Triggering project reload"
-	case ProjectKillStart:
-		m = "Killing project"
-	case ProjectKillDone:
-		m = "Project killed"
-	case ProjectStartStart:
-		m = "Starting project"
-	case ProjectStartDone:
-		m = "Project started"
-	case ProjectBuildStart:
-		m = "Building project"
-	case ProjectBuildDone:
-		m = "Project built"
-	case ProjectPauseStart:
-		m = "Pausing project"
-	case ProjectPauseDone:
-		m = "Project paused"
-	case ProjectUnpauseStart:
-		m = "Unpausing project"
-	case ProjectUnpauseDone:
-		m = "Project unpaused"
+// NewServiceAddEvent creates a new Service Add event
+func NewServiceAddEvent(serviceName string) Event {
+	return &ServiceAdd{
+		NewEvent("Service Added", serviceName),
 	}
+}
 
-	if m == "" {
-		m = fmt.Sprintf("EventType: %d", int(e))
+// VolumeAdd Represents a volume being added to a project service
+type VolumeAdd struct {
+	Event
+	Driver string
+}
+
+// NewVolumeAddEvent creates a new Volume Add event
+func NewVolumeAddEvent(serviceName, volumeDriver string) Event {
+	return &VolumeAdd{
+		Event:  NewEvent("Volume Added", serviceName),
+		Driver: volumeDriver,
 	}
+}
 
-	return m
+// NetworkAdd Represents a network being added to a project service
+type NetworkAdd struct {
+	Event
+	Driver string
+}
+
+// NewNetworkAddEvent creates a new Network Add event
+func NewNetworkAddEvent(serviceName, networkDriver string) Event {
+	return &NetworkAdd{
+		Event:  NewEvent("Network Added", serviceName),
+		Driver: networkDriver,
+	}
+}
+
+// ServiceBuildStart Represents a service build starting
+type ServiceBuildStart struct {
+	Event
+}
+
+// NewServiceBuildStartEvent creates a new service build starting event
+func NewServiceBuildStartEvent(serviceName string) Event {
+	return &ServiceBuildStart{
+		NewEvent("Building Service", serviceName),
+	}
+}
+
+// ServiceBuildDone represents a service build completing
+type ServiceBuildDone struct {
+	Event
+}
+
+// NewServiceBuildDoneEvent creates a new service build done event
+func NewServiceBuildDoneEvent(serviceName string) Event {
+	return &ServiceBuildDone{
+		NewEvent("Service Built", serviceName),
+	}
+}
+
+// ServiceBuildFailed represents a service build failing
+type ServiceBuildFailed struct {
+	Event
+	err error
+}
+
+// NewServiceBuildFailedEvent creates a new service build failed event
+func NewServiceBuildFailedEvent(serviceName string, err error) Event {
+	return &ServiceBuildFailed{
+		Event: NewEvent("Service Built Failed", serviceName),
+		err:   err,
+	}
+}
+
+// ServiceCreateStart represents a service create starting
+type ServiceCreateStart struct {
+	Event
+}
+
+// NewServiceCreateStartEvent creates a new service create starting event
+func NewServiceCreateStartEvent(serviceName string) Event {
+	return &ServiceCreateStart{
+		NewEvent("Creating Service", serviceName),
+	}
+}
+
+// ServiceCreateDone represents a service create completing
+type ServiceCreateDone struct {
+	Event
+}
+
+// NewServiceCreateDoneEvent creates a new service create done event
+func NewServiceCreateDoneEvent(serviceName string) Event {
+	return &ServiceCreateDone{
+		NewEvent("Service Created", serviceName),
+	}
+}
+
+// ServiceCreateFailed represents a service create failing
+type ServiceCreateFailed struct {
+	Event
+	err error
+}
+
+// NewServiceCreateFailedEvent creates a new service create failed event
+func NewServiceCreateFailedEvent(serviceName string, err error) Event {
+	return &ServiceCreateFailed{
+		Event: NewEvent("Service Create Failed", serviceName),
+		err:   err,
+	}
+}
+
+// ServiceStopStart represents a service stop starting
+type ServiceStopStart struct {
+	Event
+}
+
+// NewServiceStopStartEvent creates a new service stop starting event
+func NewServiceStopStartEvent(serviceName string) Event {
+	return &ServiceStopStart{
+		NewEvent("Stopping Service", serviceName),
+	}
+}
+
+// ServiceStopDone represents a service stop completing
+type ServiceStopDone struct {
+	Event
+}
+
+// NewServiceStopDoneEvent creates a new service stop done event
+func NewServiceStopDoneEvent(serviceName string) Event {
+	return &ServiceStopDone{
+		Event: NewEvent("Service Stopped", serviceName),
+	}
+}
+
+// ServiceStopFailed represents a service stop failing
+type ServiceStopFailed struct {
+	Event
+	err error
+}
+
+// NewServiceStopFailedEvent creates a new service stop failed event
+func NewServiceStopFailedEvent(serviceName string, err error) Event {
+	return &ServiceStopFailed{
+		Event: NewEvent("Service Stop Failed", serviceName),
+		err:   err,
+	}
+}
+
+// ServiceRestartStart represents a service restart starting
+type ServiceRestartStart struct {
+	Event
+}
+
+// NewServiceRestartStartEvent creates a new service restart starting event
+func NewServiceRestartStartEvent(serviceName string) Event {
+	return &ServiceRestartStart{
+		NewEvent("Restarting Service", serviceName),
+	}
+}
+
+// ServiceRestartDone represents a service restart completing
+type ServiceRestartDone struct {
+	Event
+}
+
+// NewServiceRestartDoneEvent creates a new service restart done event
+func NewServiceRestartDoneEvent(serviceName string) Event {
+	return &ServiceRestartDone{
+		NewEvent("Service Restarted", serviceName),
+	}
+}
+
+// ServiceRestartFailed represents a service restart failing
+type ServiceRestartFailed struct {
+	Event
+	err error
+}
+
+// NewServiceRestartFailedEvent creates a new service restart failed event
+func NewServiceRestartFailedEvent(serviceName string, err error) Event {
+	return &ServiceRestartFailed{
+		Event: NewEvent("Service Restart Failed", serviceName),
+		err:   err,
+	}
+}
+
+// ServiceStartStart represents a service start starting
+type ServiceStartStart struct {
+	Event
+}
+
+// NewServiceStartStartEvent creates a new service start starting event
+func NewServiceStartStartEvent(serviceName string) Event {
+	return &ServiceStartStart{
+		NewEvent("Starting Service", serviceName),
+	}
+}
+
+// ServiceStartDone represents a service start completing
+type ServiceStartDone struct {
+	Event
+}
+
+// NewServiceStartDoneEvent creates a new service start done event
+func NewServiceStartDoneEvent(serviceName string) Event {
+	return &ServiceStartDone{
+		NewEvent("Service Started", serviceName),
+	}
+}
+
+// ServiceStartFailed represents a service start failing
+type ServiceStartFailed struct {
+	Event
+	err error
+}
+
+// NewServiceStartFailedEvent creates a new service start failed event
+func NewServiceStartFailedEvent(serviceName string, err error) Event {
+	return &ServiceStartFailed{
+		Event: NewEvent("Service Start Failed", serviceName),
+		err:   err,
+	}
+}
+
+// ServiceRunStart represents a service run starting
+type ServiceRunStart struct {
+	Event
+}
+
+// NewServiceRunStartEvent creates a new service run starting event
+func NewServiceRunStartEvent(serviceName string) Event {
+	return &ServiceRunStart{
+		NewEvent("Running Service", serviceName),
+	}
+}
+
+// ServiceRunDone represents a service run completing
+type ServiceRunDone struct {
+	Event
+}
+
+// NewServiceRunDoneEvent creates a new service run done event
+func NewServiceRunDoneEvent(serviceName string) Event {
+	return &ServiceRunDone{
+		NewEvent("Service Run", serviceName),
+	}
+}
+
+// ServiceRunFailed represents a service run failing
+type ServiceRunFailed struct {
+	Event
+	err error
+}
+
+// NewServiceRunFailedEvent creates a new service run failed event
+func NewServiceRunFailedEvent(serviceName string, err error) Event {
+	return &ServiceRunFailed{
+		Event: NewEvent("Service Run Failed", serviceName),
+		err:   err,
+	}
+}
+
+// ServiceUpStart represents a service up starting
+type ServiceUpStart struct {
+	Event
+}
+
+// NewServiceUpStartEvent creates a new service up starting event
+func NewServiceUpStartEvent(serviceName string) Event {
+	return &ServiceUpStart{
+		NewEvent("Starting Service", serviceName),
+	}
+}
+
+// ServiceUpDone represents a service up completing
+type ServiceUpDone struct {
+	Event
+}
+
+// NewServiceUpDoneEvent creates a new service up done event
+func NewServiceUpDoneEvent(serviceName string) Event {
+	return &ServiceUpDone{
+		NewEvent("Service Started", serviceName),
+	}
+}
+
+// ServiceUpFailed represents a service up failing
+type ServiceUpFailed struct {
+	Event
+	err error
+}
+
+// NewServiceUpFailedEvent creates a new service up failed event
+func NewServiceUpFailedEvent(serviceName string, err error) Event {
+	return &ServiceUpFailed{
+		Event: NewEvent("Service Start Failed", serviceName),
+		err:   err,
+	}
+}
+
+// ServiceUpIgnored represents a service up being ignored
+type ServiceUpIgnored struct {
+	Event
+}
+
+// NewServiceUpIgnoredEvent creates a new service up ignore event
+func NewServiceUpIgnoredEvent(serviceName string) Event {
+	return &ServiceUpIgnored{
+		NewEvent("Service Start Ignored", serviceName),
+	}
+}
+
+// ServicePullStart represents a service pull starting
+type ServicePullStart struct {
+	Event
+}
+
+// NewServicePullStartEvent creates a new service pull starting event
+func NewServicePullStartEvent(serviceName string) Event {
+	return &ServicePullStart{
+		NewEvent("Pulling Service", serviceName),
+	}
+}
+
+// ServicePullDone represents a service pull completing
+type ServicePullDone struct {
+	Event
+}
+
+// NewServicePullDoneEvent creates a new service pull done event
+func NewServicePullDoneEvent(serviceName string) Event {
+	return &ServicePullDone{
+		NewEvent("Service Pulled", serviceName),
+	}
+}
+
+// ServicePullFailed represents a service pull failing
+type ServicePullFailed struct {
+	Event
+	err error
+}
+
+// NewServicePullFailedEvent creates a new service pull failed event
+func NewServicePullFailedEvent(serviceName string, err error) Event {
+	return &ServicePullFailed{
+		Event: NewEvent("Service Pull Failed", serviceName),
+		err:   err,
+	}
+}
+
+// ServiceDeleteStart represents a service delete starting
+type ServiceDeleteStart struct {
+	Event
+}
+
+// NewServiceDeleteStartEvent creates a new service delete starting event
+func NewServiceDeleteStartEvent(serviceName string) Event {
+	return &ServiceDeleteStart{
+		NewEvent("Deleting Service", serviceName),
+	}
+}
+
+// ServiceDeleteDone represents a service delete completing
+type ServiceDeleteDone struct {
+	Event
+}
+
+// NewServiceDeleteDoneEvent creates a new service delete done event
+func NewServiceDeleteDoneEvent(serviceName string) Event {
+	return &ServiceDeleteDone{
+		NewEvent("Service Deleted", serviceName),
+	}
+}
+
+// ServiceDeleteFailed represents a service delete failing
+type ServiceDeleteFailed struct {
+	Event
+	err error
+}
+
+// NewServiceDeleteFailedEvent creates a new service delete failed event
+func NewServiceDeleteFailedEvent(serviceName string, err error) Event {
+	return &ServiceDeleteFailed{
+		Event: NewEvent("Service Delete Failed", serviceName),
+		err:   err,
+	}
+}
+
+// ServiceKillStart represents a service kill starting
+type ServiceKillStart struct {
+	Event
+}
+
+// NewServiceKillStartEvent creates a new service kill starting event
+func NewServiceKillStartEvent(serviceName string) Event {
+	return &ServiceKillStart{
+		NewEvent("Killing Service", serviceName),
+	}
+}
+
+// ServiceKillDone represents a service kill completing
+type ServiceKillDone struct {
+	Event
+}
+
+// NewServiceKillDoneEvent creates a new service kill done event
+func NewServiceKillDoneEvent(serviceName string) Event {
+	return &ServiceKillDone{
+		NewEvent("Service Killed", serviceName),
+	}
+}
+
+// ServiceKillFailed represents a service kill failing
+type ServiceKillFailed struct {
+	Event
+	err error
+}
+
+// NewServiceKillFailedEvent creates a new service kill failed event
+func NewServiceKillFailedEvent(serviceName string, err error) Event {
+	return &ServiceKillFailed{
+		Event: NewEvent("Service Kill Failed", serviceName),
+		err:   err,
+	}
+}
+
+// ServicePauseStart represents a service pause starting
+type ServicePauseStart struct {
+	Event
+}
+
+// NewServicePauseStartEvent creates a new service pause starting event
+func NewServicePauseStartEvent(serviceName string) Event {
+	return &ServicePauseStart{
+		NewEvent("Pausing Service", serviceName),
+	}
+}
+
+// ServicePauseDone represents a service pause completing
+type ServicePauseDone struct {
+	Event
+}
+
+// NewServicePauseDoneEvent creates a new service pause done event
+func NewServicePauseDoneEvent(serviceName string) Event {
+	return &ServicePauseDone{
+		NewEvent("Service Paused", serviceName),
+	}
+}
+
+// ServicePauseFailed represents a service pause failing
+type ServicePauseFailed struct {
+	Event
+	err error
+}
+
+// NewServicePauseFailedEvent creates a new service pause failed event
+func NewServicePauseFailedEvent(serviceName string, err error) Event {
+	return &ServicePauseFailed{
+		Event: NewEvent("Service Pause Failed", serviceName),
+		err:   err,
+	}
+}
+
+// ServiceUnpauseStart represents a service unpause starting
+type ServiceUnpauseStart struct {
+	Event
+}
+
+// NewServiceUnpauseStartEvent creates a new service unpause starting event
+func NewServiceUnpauseStartEvent(serviceName string) Event {
+	return &ServiceUnpauseStart{
+		NewEvent("Unpausing Service", serviceName),
+	}
+}
+
+// ServiceUnpauseDone represents a service unpause completing
+type ServiceUnpauseDone struct {
+	Event
+}
+
+// NewServiceUnpauseDoneEvent creates a new service unpause done event
+func NewServiceUnpauseDoneEvent(serviceName string) Event {
+	return &ServiceUnpauseDone{
+		NewEvent("Service Unpaused", serviceName),
+	}
+}
+
+// ServiceUnpauseFailed represents a service unpause failing
+type ServiceUnpauseFailed struct {
+	Event
+	err error
+}
+
+// NewServiceUnpauseFailedEvent creates a new service unpause failed event
+func NewServiceUnpauseFailedEvent(serviceName string, err error) Event {
+	return &ServiceUnpauseFailed{
+		Event: NewEvent("Service Unpause Failed", serviceName),
+		err:   err,
+	}
+}
+
+// ServiceDownStart represents a service down starting
+type ServiceDownStart struct {
+	Event
+}
+
+// NewServiceDownStartEvent creates a new service down starting event
+func NewServiceDownStartEvent(serviceName string) Event {
+	return &ServiceDownStart{
+		NewEvent("Stopping Service", serviceName),
+	}
+}
+
+// ServiceDownDone represents a service down completing
+type ServiceDownDone struct {
+	Event
+}
+
+// NewServiceDownDoneEvent creates a new service down done event
+func NewServiceDownDoneEvent(serviceName string) Event {
+	return &ServiceDownDone{
+		NewEvent("Service Stopped", serviceName),
+	}
+}
+
+// ServiceDownFailed represents a service down failing
+type ServiceDownFailed struct {
+	Event
+	err error
+}
+
+// NewServiceDownFailedEvent creates a new service down failed event
+func NewServiceDownFailedEvent(serviceName string, err error) Event {
+	return &ServiceDownFailed{
+		Event: NewEvent("Service Stop Failed", serviceName),
+		err:   err,
+	}
+}
+
+// ProjectRestartStart represents a project restart starting
+type ProjectRestartStart struct {
+	Event
+}
+
+// NewProjectRestartStartEvent creates a new project restart starting event
+func NewProjectRestartStartEvent(serviceName string) Event {
+	return &ProjectRestartStart{
+		NewEvent("Restarting Project", serviceName),
+	}
+}
+
+// ProjectRestartDone represents a project restart completing
+type ProjectRestartDone struct {
+	Event
+}
+
+// NewProjectRestartDoneEvent creates a new project restart done event
+func NewProjectRestartDoneEvent(serviceName string) Event {
+	return &ProjectRestartDone{
+		NewEvent("Project Restarted", serviceName),
+	}
+}
+
+// ProjectRestartFailed represents a project restart failing
+type ProjectRestartFailed struct {
+	Event
+	err error
+}
+
+// NewProjectRestartFailedEvent creates a new project restart failed event
+func NewProjectRestartFailedEvent(serviceName string, err error) Event {
+	return &ProjectRestartFailed{
+		Event: NewEvent("Project Restart Failed", serviceName),
+		err:   err,
+	}
+}
+
+// ProjectStartStart represents a project start starting
+type ProjectStartStart struct {
+	Event
+}
+
+// NewProjectStartStartEvent creates a new project start starting event
+func NewProjectStartStartEvent(serviceName string) Event {
+	return &ProjectStartStart{
+		NewEvent("Starting Project", serviceName),
+	}
+}
+
+// ProjectStartDone represents a project start completing
+type ProjectStartDone struct {
+	Event
+}
+
+// NewProjectStartDoneEvent creates a new project start done event
+func NewProjectStartDoneEvent(serviceName string) Event {
+	return &ProjectStartDone{
+		NewEvent("Project Started", serviceName),
+	}
+}
+
+// ProjectStartFailed represents a project start failing
+type ProjectStartFailed struct {
+	Event
+	err error
+}
+
+// NewProjectStartFailedEvent creates a new project start failed event
+func NewProjectStartFailedEvent(serviceName string, err error) Event {
+	return &ProjectStartFailed{
+		Event: NewEvent("Project Start Failed", serviceName),
+		err:   err,
+	}
+}
+
+// ProjectUpStart represents a project up starting
+type ProjectUpStart struct {
+	Event
+}
+
+// NewProjectUpStartEvent creates a new project up starting event
+func NewProjectUpStartEvent(serviceName string) Event {
+	return &ProjectUpStart{
+		NewEvent("Starting Project", serviceName),
+	}
+}
+
+// ProjectUpDone represents a project up completing
+type ProjectUpDone struct {
+	Event
+}
+
+// NewProjectUpDoneEvent creates a new project up done event
+func NewProjectUpDoneEvent(serviceName string) Event {
+	return &ProjectUpDone{
+		NewEvent("Project Started", serviceName),
+	}
+}
+
+// ProjectUpFailed represents a project up failing
+type ProjectUpFailed struct {
+	Event
+	err error
+}
+
+// NewProjectUpFailedEvent creates a new project up failed event
+func NewProjectUpFailedEvent(serviceName string, err error) Event {
+	return &ProjectUpFailed{
+		Event: NewEvent("Project Up Failed", serviceName),
+		err:   err,
+	}
+}
+
+// ProjectDownStart represents a project down starting
+type ProjectDownStart struct {
+	Event
+}
+
+// NewProjectDownStartEvent creates a new project down starting event
+func NewProjectDownStartEvent(serviceName string) Event {
+	return &ProjectDownStart{
+		NewEvent("Stopping Project", serviceName),
+	}
+}
+
+// ProjectDownDone represents a project down completing
+type ProjectDownDone struct {
+	Event
+}
+
+// NewProjectDownDoneEvent creates a new project down done event
+func NewProjectDownDoneEvent(serviceName string) Event {
+	return &ProjectDownDone{
+		NewEvent("Project Stopped", serviceName),
+	}
+}
+
+// ProjectDownFailed represents a project down failing
+type ProjectDownFailed struct {
+	Event
+	err error
+}
+
+// NewProjectDownFailedEvent creates a new project down failed event
+func NewProjectDownFailedEvent(serviceName string, err error) Event {
+	return &ProjectDownFailed{
+		Event: NewEvent("Project Down Failed", serviceName),
+		err:   err,
+	}
+}
+
+// ProjectDeleteStart represents a project delete starting
+type ProjectDeleteStart struct {
+	Event
+}
+
+// NewProjectDeleteStartEvent creates a new project delete starting event
+func NewProjectDeleteStartEvent(serviceName string) Event {
+	return &ProjectDeleteStart{
+		NewEvent("Deleting Project", serviceName),
+	}
+}
+
+// ProjectDeleteDone represents a project delete completing
+type ProjectDeleteDone struct {
+	Event
+}
+
+// NewProjectDeleteDoneEvent creates a new project delete done event
+func NewProjectDeleteDoneEvent(serviceName string) Event {
+	return &ProjectDeleteDone{
+		NewEvent("Project Deleted", serviceName),
+	}
+}
+
+// ProjectDeleteFailed represents a project delete failing
+type ProjectDeleteFailed struct {
+	Event
+	err error
+}
+
+// NewProjectDeleteFailedEvent creates a new project delete failed event
+func NewProjectDeleteFailedEvent(serviceName string, err error) Event {
+	return &ProjectDeleteFailed{
+		Event: NewEvent("Project Delete Failed", serviceName),
+		err:   err,
+	}
+}
+
+// ProjectKillStart represents a project kill starting
+type ProjectKillStart struct {
+	Event
+}
+
+// NewProjectKillStartEvent creates a new project kill starting event
+func NewProjectKillStartEvent(serviceName string) Event {
+	return &ProjectKillStart{
+		NewEvent("Killing Project", serviceName),
+	}
+}
+
+// ProjectKillDone represents a project kill completing
+type ProjectKillDone struct {
+	Event
+}
+
+// NewProjectKillDoneEvent creates a new project kill done event
+func NewProjectKillDoneEvent(serviceName string) Event {
+	return &ProjectKillDone{
+		NewEvent("Project Killed", serviceName),
+	}
+}
+
+// ProjectKillFailed represents a project kill failing
+type ProjectKillFailed struct {
+	Event
+	err error
+}
+
+// NewProjectKillFailedEvent creates a new project kill failed event
+func NewProjectKillFailedEvent(serviceName string, err error) Event {
+	return &ProjectKillFailed{
+		Event: NewEvent("Project Kill Failed", serviceName),
+		err:   err,
+	}
+}
+
+// ProjectPauseStart represents a project pause starting
+type ProjectPauseStart struct {
+	Event
+}
+
+// NewProjectPauseStartEvent creates a new project pause starting event
+func NewProjectPauseStartEvent(serviceName string) Event {
+	return &ProjectPauseStart{
+		NewEvent("Pausing Project", serviceName),
+	}
+}
+
+// ProjectPauseDone represents a project pause completing
+type ProjectPauseDone struct {
+	Event
+}
+
+// NewProjectPauseDoneEvent creates a new project pause done event
+func NewProjectPauseDoneEvent(serviceName string) Event {
+	return &ProjectPauseDone{
+		NewEvent("Project Paused", serviceName),
+	}
+}
+
+// ProjectPauseFailed represents a project pause failing
+type ProjectPauseFailed struct {
+	Event
+	err error
+}
+
+// NewProjectPauseFailedEvent creates a new project pause failed event
+func NewProjectPauseFailedEvent(serviceName string, err error) Event {
+	return &ProjectPauseFailed{
+		Event: NewEvent("Project Pause Failed", serviceName),
+		err:   err,
+	}
+}
+
+// ProjectUnpauseStart represents a project unpause starting
+type ProjectUnpauseStart struct {
+	Event
+}
+
+// NewProjectUnpauseStartEvent creates a new project unpause starting event
+func NewProjectUnpauseStartEvent(serviceName string) Event {
+	return &ProjectUnpauseStart{
+		NewEvent("Unpausing Project", serviceName),
+	}
+}
+
+// ProjectUnpauseDone represents a project unpause completing
+type ProjectUnpauseDone struct {
+	Event
+}
+
+// NewProjectUnpauseDoneEvent creates a new project unpause done event
+func NewProjectUnpauseDoneEvent(serviceName string) Event {
+	return &ProjectUnpauseDone{
+		NewEvent("Project Unpaused", serviceName),
+	}
+}
+
+// ProjectUnpauseFailed represents a project unpause failing
+type ProjectUnpauseFailed struct {
+	Event
+	err error
+}
+
+// NewProjectUnpauseFailedEvent creates a new project unpause failed event
+func NewProjectUnpauseFailedEvent(serviceName string, err error) Event {
+	return &ProjectUnpauseFailed{
+		Event: NewEvent("Project Unpause Failed", serviceName),
+		err:   err,
+	}
+}
+
+// ProjectBuildStart represents a project build starting
+type ProjectBuildStart struct {
+	Event
+}
+
+// NewProjectBuildStartEvent creates a new project build starting event
+func NewProjectBuildStartEvent(serviceName string) Event {
+	return &ProjectBuildStart{
+		NewEvent("Building Project", serviceName),
+	}
+}
+
+// ProjectBuildDone represents a project build completing
+type ProjectBuildDone struct {
+	Event
+}
+
+// NewProjectBuildDoneEvent creates a new project build done event
+func NewProjectBuildDoneEvent(serviceName string) Event {
+	return &ProjectBuildDone{
+		NewEvent("Project Built", serviceName),
+	}
+}
+
+// ProjectBuildFailed represents a project build failing
+type ProjectBuildFailed struct {
+	Event
+	err error
+}
+
+// NewProjectBuildFailedEvent creates a new project build failed event
+func NewProjectBuildFailedEvent(serviceName string, err error) Event {
+	return &ProjectBuildFailed{
+		Event: NewEvent("Project Build Failed", serviceName),
+		err:   err,
+	}
+}
+
+// ProjectCreateStart represents a project creating
+type ProjectCreateStart struct {
+	Event
+}
+
+// NewProjectCreateStartEvent creates a new project creating event
+func NewProjectCreateStartEvent(serviceName string) Event {
+	return &ProjectCreateStart{
+		NewEvent("Creating Project", serviceName),
+	}
+}
+
+// ProjectCreateDone represents a project create completing
+type ProjectCreateDone struct {
+	Event
+}
+
+// NewProjectCreateDoneEvent creates a new project create done event
+func NewProjectCreateDoneEvent(serviceName string) Event {
+	return &ProjectCreateDone{
+		NewEvent("Project Created", serviceName),
+	}
+}
+
+// ProjectCreateFailed represents a project create failing
+type ProjectCreateFailed struct {
+	Event
+	err error
+}
+
+// NewProjectCreateFailedEvent creates a new project create failed event
+func NewProjectCreateFailedEvent(serviceName string, err error) Event {
+	return &ProjectCreateFailed{
+		Event: NewEvent("Project Create Failed", serviceName),
+		err:   err,
+	}
+}
+
+// ProjectStopStart represents a project stop
+type ProjectStopStart struct {
+	Event
+}
+
+// NewProjectStopStartEvent creates a new project stopping event
+func NewProjectStopStartEvent(serviceName string) Event {
+	return &ProjectStopStart{
+		NewEvent("Stopping Project", serviceName),
+	}
+}
+
+// ProjectStopDone represents a project stop completing
+type ProjectStopDone struct {
+	Event
+}
+
+// NewProjectStopDoneEvent creates a new project stop done event
+func NewProjectStopDoneEvent(serviceName string) Event {
+	return &ProjectStopDone{
+		NewEvent("Project Stopped", serviceName),
+	}
+}
+
+// ProjectStopFailed represents a project stop failing
+type ProjectStopFailed struct {
+	Event
+	err error
+}
+
+// NewProjectStopFailedEvent creates a new project stop failed event
+func NewProjectStopFailedEvent(serviceName string, err error) Event {
+	return &ProjectStopFailed{
+		Event: NewEvent("Project Stop Failed", serviceName),
+		err:   err,
+	}
+}
+
+// ProjectReloadDone represents a project reload completing
+type ProjectReloadDone struct {
+	Event
+}
+
+// NewProjectReloadDoneEvent creates a new project reload done event
+func NewProjectReloadDoneEvent(serviceName string) Event {
+	return &ProjectReloadDone{
+		NewEvent("Project Reloaded", serviceName),
+	}
+}
+
+// ProjectReloadTriggered represents a project reload triggered
+type ProjectReloadTriggered struct {
+	Event
+}
+
+// NewProjectReloadTriggeredEvent creates a new project reload triggered event
+func NewProjectReloadTriggeredEvent(serviceName string) Event {
+	return &ProjectReloadTriggered{
+		NewEvent("Reloading Project", serviceName),
+	}
+}
+
+// ContainerCreateStart represents a container create
+type ContainerCreateStart struct {
+	Event
+	ContainerName string
+}
+
+// NewContainerCreateStartEvent creates a new container creating event
+func NewContainerCreateStartEvent(serviceName, containerName string) Event {
+	return &ContainerCreateStart{
+		Event:         NewEvent("Creating Container", serviceName),
+		ContainerName: containerName,
+	}
+}
+
+// ContainerCreateDone represents a container create completing
+type ContainerCreateDone struct {
+	Event
+	ContainerName string
+}
+
+// NewContainerCreateDoneEvent creates a new container create done event
+func NewContainerCreateDoneEvent(serviceName, containerName string) Event {
+	return &ContainerCreateDone{
+		Event:         NewEvent("Container Created", serviceName),
+		ContainerName: containerName,
+	}
+}
+
+// ContainerCreateFailed represents a container create failing
+type ContainerCreateFailed struct {
+	Event
+	err           error
+	ContainerName string
+}
+
+// NewContainerCreateFailedEvent creates a new container create failed event
+func NewContainerCreateFailedEvent(serviceName, containerName string, err error) Event {
+	return &ContainerCreateFailed{
+		Event:         NewEvent("Container Create Failed", serviceName),
+		err:           err,
+		ContainerName: containerName,
+	}
+}
+
+// ContainerStartStart represents a container start
+type ContainerStartStart struct {
+	Event
+	ContainerName string
+}
+
+// NewContainerStartStartEvent creates a new container starting event
+func NewContainerStartStartEvent(serviceName, containerName string) Event {
+	return &ContainerStartStart{
+		Event:         NewEvent("Container Starting", serviceName),
+		ContainerName: containerName,
+	}
+}
+
+// ContainerStartDone represents a container start completing
+type ContainerStartDone struct {
+	Event
+	ContainerName string
+}
+
+// NewContainerStartDoneEvent creates a new container start done event
+func NewContainerStartDoneEvent(serviceName, containerName string) Event {
+	return &ContainerStartDone{
+		Event:         NewEvent("Container Started", serviceName),
+		ContainerName: containerName,
+	}
+}
+
+// ContainerStartFailed represents a container start failing
+type ContainerStartFailed struct {
+	Event
+	err           error
+	ContainerName string
+}
+
+// NewContainerStartFailedEvent creates a new container start failed event
+func NewContainerStartFailedEvent(serviceName, containerName string, err error) Event {
+	return &ContainerStartFailed{
+		Event:         NewEvent("Container Start Failed", serviceName),
+		err:           err,
+		ContainerName: containerName,
+	}
 }

--- a/project/events/events_test.go
+++ b/project/events/events_test.go
@@ -1,21 +1,72 @@
 package events
 
 import (
-	"fmt"
+	"errors"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
-func TestEventEquality(t *testing.T) {
-	if fmt.Sprintf("%s", ServiceStart) != "Started" ||
-		fmt.Sprintf("%v", ServiceStart) != "Started" {
-		t.Fatalf("EventServiceStart String() doesn't work: %s %v", ServiceStart, ServiceStart)
+const (
+	action      = "foo"
+	serviceName = "bar"
+)
+
+var (
+	errTest = errors.New("test error")
+)
+
+func TestNewEvent(t *testing.T) {
+	event := NewEvent(action, serviceName)
+	assert.Equal(t, serviceName, event.Service())
+	assert.Equal(t, action, event.String())
+}
+
+func TestEventWrapper(t *testing.T) {
+	startedFunc := func(s string) Event {
+		return NewEvent("started", s)
 	}
 
-	if fmt.Sprintf("%s", ServiceStart) != fmt.Sprintf("%s", ServiceUp) {
-		t.Fatal("Event messages do not match")
+	doneFunc := func(s string) Event {
+		return NewEvent("done", s)
+	}
+	var failedErr error
+	failedFunc := func(s string, err error) Event {
+		failedErr = err
+		return NewEvent("failed", s)
 	}
 
-	if ServiceStart == ServiceUp {
-		t.Fatal("Events match")
-	}
+	eventWrapper := NewEventWrapper(action, startedFunc, doneFunc, failedFunc)
+	assert.Equal(t, action, eventWrapper.Action())
+
+	e1 := eventWrapper.Started(serviceName)
+	assert.Equal(t, "started", e1.String())
+	assert.Equal(t, serviceName, e1.Service())
+
+	e2 := eventWrapper.Done(serviceName)
+	assert.Equal(t, "done", e2.String())
+	assert.Equal(t, serviceName, e2.Service())
+
+	e3 := eventWrapper.Failed(serviceName, errTest)
+	assert.Equal(t, "failed", e3.String())
+	assert.Equal(t, serviceName, e3.Service())
+	assert.Equal(t, errTest, failedErr)
+}
+
+func TestEventWrapperNil(t *testing.T) {
+	eventWrapper := NewEventWrapper(action, nil, nil, nil)
+	assert.Equal(t, action, eventWrapper.Action())
+
+	assert.Nil(t, eventWrapper.Started(serviceName))
+	assert.Nil(t, eventWrapper.Done(serviceName))
+	assert.Nil(t, eventWrapper.Failed(serviceName, errTest))
+}
+
+func TestDummyEventWrapper(t *testing.T) {
+	eventWrapper := NewDummyEventWrapper(action)
+	assert.Equal(t, action, eventWrapper.Action())
+
+	assert.Nil(t, eventWrapper.Started(serviceName))
+	assert.Nil(t, eventWrapper.Done(serviceName))
+	assert.Nil(t, eventWrapper.Failed(serviceName, errTest))
 }

--- a/project/listener.go
+++ b/project/listener.go
@@ -1,35 +1,10 @@
 package project
 
 import (
-	"bytes"
+	"encoding/json"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/codeship/libcompose/project/events"
-)
-
-var (
-	infoEvents = map[events.EventType]bool{
-		events.ServiceDeleteStart:  true,
-		events.ServiceDelete:       true,
-		events.ServiceDownStart:    true,
-		events.ServiceDown:         true,
-		events.ServiceStopStart:    true,
-		events.ServiceStop:         true,
-		events.ServiceKillStart:    true,
-		events.ServiceKill:         true,
-		events.ServiceCreateStart:  true,
-		events.ServiceCreate:       true,
-		events.ServiceStartStart:   true,
-		events.ServiceStart:        true,
-		events.ServiceRestartStart: true,
-		events.ServiceRestart:      true,
-		events.ServiceUpStart:      true,
-		events.ServiceUp:           true,
-		events.ServicePauseStart:   true,
-		events.ServicePause:        true,
-		events.ServiceUnpauseStart: true,
-		events.ServiceUnpause:      true,
-	}
 )
 
 type defaultListener struct {
@@ -50,32 +25,93 @@ func NewDefaultListener(p *Project) chan<- events.Event {
 
 func (d *defaultListener) start() {
 	for event := range d.listenChan {
-		buffer := bytes.NewBuffer(nil)
-		if event.Data != nil {
-			for k, v := range event.Data {
-				if buffer.Len() > 0 {
-					buffer.WriteString(", ")
-				}
-				buffer.WriteString(k)
-				buffer.WriteString("=")
-				buffer.WriteString(v)
-			}
-		}
+		data, err := json.Marshal(event)
 
-		if event.EventType == events.ServiceUp {
+		switch event.(type) {
+		case *events.ServiceUpDone:
 			d.upCount++
 		}
 
 		logf := logrus.Debugf
 
-		if infoEvents[event.EventType] {
+		if infoLevel(event) {
 			logf = logrus.Infof
 		}
 
-		if event.ServiceName == "" {
-			logf("Project [%s]: %s %s", d.project.Name, event.EventType, buffer.Bytes())
+		if err != nil {
+			logf("Failed to Marshal Event [%s] for Project %s. Error: [%s]", event.String(), d.project.Name, err.Error())
+
+		} else if event.Service() == "" {
+			logf("Project [%s]: %s %s", d.project.Name, event.String(), data)
 		} else {
-			logf("[%d/%d] [%s]: %s %s", d.upCount, d.project.ServiceConfigs.Len(), event.ServiceName, event.EventType, buffer.Bytes())
+			logf("[%d/%d] [%s]: %s %s", d.upCount, d.project.ServiceConfigs.Len(), event.Service(), event.String(), data)
 		}
+	}
+}
+
+func infoLevel(event events.Event) bool {
+	switch event.(type) {
+	case *events.ServiceDeleteStart:
+		return true
+	case *events.ServiceDeleteDone:
+		return true
+	case *events.ServiceDeleteFailed:
+		return true
+	case *events.ServiceDownStart:
+		return true
+	case *events.ServiceDownDone:
+		return true
+	case *events.ServiceDownFailed:
+		return true
+	case *events.ServiceStopStart:
+		return true
+	case *events.ServiceStopDone:
+		return true
+	case *events.ServiceStopFailed:
+		return true
+	case *events.ServiceKillStart:
+		return true
+	case *events.ServiceKillDone:
+		return true
+	case *events.ServiceKillFailed:
+		return true
+	case *events.ServiceCreateStart:
+		return true
+	case *events.ServiceCreateDone:
+		return true
+	case *events.ServiceCreateFailed:
+		return true
+	case *events.ServiceStartStart:
+		return true
+	case *events.ServiceStartDone:
+		return true
+	case *events.ServiceStartFailed:
+		return true
+	case *events.ServiceRestartStart:
+		return true
+	case *events.ServiceRestartDone:
+		return true
+	case *events.ServiceRestartFailed:
+		return true
+	case *events.ServiceUpStart:
+		return true
+	case *events.ServiceUpDone:
+		return true
+	case *events.ServiceUpFailed:
+		return true
+	case *events.ServicePauseStart:
+		return true
+	case *events.ServicePauseDone:
+		return true
+	case *events.ServicePauseFailed:
+		return true
+	case *events.ServiceUnpauseStart:
+		return true
+	case *events.ServiceUnpauseDone:
+		return true
+	case *events.ServiceUnpauseFailed:
+		return true
+	default:
+		return false
 	}
 }

--- a/project/project.go
+++ b/project/project.go
@@ -363,13 +363,11 @@ func (p *Project) perform(eventWrapper events.EventWrapper, services []string, a
 
 	err := p.forEach(services, action, cycleAction)
 
-
-  if err != nil {
- 		p.Notify(eventWrapper.Done(""))
+	if err != nil {
+		p.Notify(eventWrapper.Done(""))
 	} else {
- 		p.Notify(eventWrapper.Failed("", err))
- 	}
-
+		p.Notify(eventWrapper.Failed("", err))
+	}
 	return err
 }
 

--- a/project/project_build.go
+++ b/project/project_build.go
@@ -8,9 +8,12 @@ import (
 )
 
 // Build builds the specified services (like docker build).
+// Build builds the specified services (like docker build).
 func (p *Project) Build(ctx context.Context, buildOptions options.Build, services ...string) error {
-	return p.perform(events.ProjectBuildStart, events.ProjectBuildDone, services, wrapperAction(func(wrapper *serviceWrapper, wrappers map[string]*serviceWrapper) {
-		wrapper.Do(wrappers, events.ServiceBuildStart, events.ServiceBuild, func(service Service) error {
+	eventWrapper := events.NewEventWrapper("Project Build", events.NewProjectBuildStartEvent, events.NewProjectBuildDoneEvent, events.NewProjectBuildFailedEvent)
+	return p.perform(eventWrapper, services, wrapperAction(func(wrapper *serviceWrapper, wrappers map[string]*serviceWrapper) {
+		serviceEventWrapper := events.NewEventWrapper("Service Build", events.NewServiceBuildStartEvent, events.NewServiceBuildDoneEvent, events.NewServiceBuildFailedEvent)
+		wrapper.Do(wrappers, serviceEventWrapper, func(service Service) error {
 			return service.Build(ctx, buildOptions)
 		})
 	}), nil)

--- a/project/project_containers.go
+++ b/project/project_containers.go
@@ -14,7 +14,7 @@ import (
 func (p *Project) Containers(ctx context.Context, filter Filter, services ...string) ([]string, error) {
 	containers := []string{}
 	err := p.forEach(services, wrapperAction(func(wrapper *serviceWrapper, wrappers map[string]*serviceWrapper) {
-		wrapper.Do(nil, events.NoEvent, events.NoEvent, func(service Service) error {
+		wrapper.Do(nil, events.NewDummyEventWrapper("Container List"), func(service Service) error {
 			serviceContainers, innerErr := service.Containers(ctx)
 			if innerErr != nil {
 				return innerErr

--- a/project/project_delete.go
+++ b/project/project_delete.go
@@ -8,9 +8,12 @@ import (
 )
 
 // Delete removes the specified services (like docker rm).
+// Delete removes the specified services (like docker rm).
 func (p *Project) Delete(ctx context.Context, options options.Delete, services ...string) error {
-	return p.perform(events.ProjectDeleteStart, events.ProjectDeleteDone, services, wrapperAction(func(wrapper *serviceWrapper, wrappers map[string]*serviceWrapper) {
-		wrapper.Do(nil, events.ServiceDeleteStart, events.ServiceDelete, func(service Service) error {
+	eventWrapper := events.NewEventWrapper("Project Delete", events.NewProjectDeleteStartEvent, events.NewProjectDeleteDoneEvent, events.NewProjectDeleteFailedEvent)
+	return p.perform(eventWrapper, services, wrapperAction(func(wrapper *serviceWrapper, wrappers map[string]*serviceWrapper) {
+		serviceEventWrapper := events.NewEventWrapper("Service Delete", events.NewServiceDeleteStartEvent, events.NewServiceDeleteDoneEvent, events.NewServiceDeleteFailedEvent)
+		wrapper.Do(nil, serviceEventWrapper, func(service Service) error {
 			return service.Delete(ctx, options)
 		})
 	}), nil)

--- a/project/project_down.go
+++ b/project/project_down.go
@@ -14,43 +14,53 @@ func (p *Project) Down(ctx context.Context, opts options.Down, services ...strin
 	if !opts.RemoveImages.Valid() {
 		return fmt.Errorf("--rmi flag must be local, all or empty")
 	}
-	if err := p.Stop(ctx, 10, services...); err != nil {
-		return err
-	}
-	if opts.RemoveOrphans {
-		if err := p.runtime.RemoveOrphans(ctx, p.Name, p.ServiceConfigs); err != nil {
+	p.Notify(events.NewProjectDownStartEvent(""))
+	err := func() error {
+		if err := p.Stop(ctx, 10, services...); err != nil {
 			return err
 		}
-	}
-	if err := p.Delete(ctx, options.Delete{
-		RemoveVolume: opts.RemoveVolume,
-	}, services...); err != nil {
-		return err
-	}
+		if opts.RemoveOrphans {
+			if err := p.runtime.RemoveOrphans(ctx, p.Name, p.ServiceConfigs); err != nil {
+				return err
+			}
+		}
+		if err := p.Delete(ctx, options.Delete{
+			RemoveVolume: opts.RemoveVolume,
+		}, services...); err != nil {
+			return err
+		}
 
-	networks, err := p.context.NetworksFactory.Create(p.Name, p.NetworkConfigs, p.ServiceConfigs, p.isNetworkEnabled())
-	if err != nil {
-		return err
-	}
-	if err := networks.Remove(ctx); err != nil {
-		return err
-	}
-
-	if opts.RemoveVolume {
-		volumes, err := p.context.VolumesFactory.Create(p.Name, p.VolumeConfigs, p.ServiceConfigs, p.isVolumeEnabled())
+		networks, err := p.context.NetworksFactory.Create(p.Name, p.NetworkConfigs, p.ServiceConfigs, p.isNetworkEnabled())
 		if err != nil {
 			return err
 		}
-		if err := volumes.Remove(ctx); err != nil {
+		if err := networks.Remove(ctx); err != nil {
 			return err
 		}
-	}
 
-	return p.forEach([]string{}, wrapperAction(func(wrapper *serviceWrapper, wrappers map[string]*serviceWrapper) {
-		wrapper.Do(wrappers, events.NoEvent, events.NoEvent, func(service Service) error {
-			return service.RemoveImage(ctx, opts.RemoveImages)
+		if opts.RemoveVolume {
+			volumes, err := p.context.VolumesFactory.Create(p.Name, p.VolumeConfigs, p.ServiceConfigs, p.isVolumeEnabled())
+			if err != nil {
+				return err
+			}
+			if err := volumes.Remove(ctx); err != nil {
+				return err
+			}
+		}
+
+		return p.forEach([]string{}, wrapperAction(func(wrapper *serviceWrapper, wrappers map[string]*serviceWrapper) {
+			serviceEventWrapper := events.NewEventWrapper("Service Down", events.NewServiceDownStartEvent, events.NewServiceDownDoneEvent, events.NewServiceDownFailedEvent)
+			wrapper.Do(wrappers, serviceEventWrapper, func(service Service) error {
+				return service.RemoveImage(ctx, opts.RemoveImages)
+			})
+		}), func(service Service) error {
+			return service.Create(ctx, options.Create{})
 		})
-	}), func(service Service) error {
-		return service.Create(ctx, options.Create{})
-	})
+	}()
+	if err != nil {
+		p.Notify(events.NewProjectDownFailedEvent("", err))
+	} else {
+		p.Notify(events.NewProjectDownDoneEvent(""))
+	}
+	return err
 }

--- a/project/project_kill.go
+++ b/project/project_kill.go
@@ -8,8 +8,10 @@ import (
 
 // Kill kills the specified services (like docker kill).
 func (p *Project) Kill(ctx context.Context, signal string, services ...string) error {
-	return p.perform(events.ProjectKillStart, events.ProjectKillDone, services, wrapperAction(func(wrapper *serviceWrapper, wrappers map[string]*serviceWrapper) {
-		wrapper.Do(nil, events.ServiceKillStart, events.ServiceKill, func(service Service) error {
+	eventWrapper := events.NewEventWrapper("Project Kill", events.NewProjectKillStartEvent, events.NewProjectKillDoneEvent, events.NewProjectKillFailedEvent)
+	return p.perform(eventWrapper, services, wrapperAction(func(wrapper *serviceWrapper, wrappers map[string]*serviceWrapper) {
+		serviceEventWrapper := events.NewEventWrapper("Service Pull", events.NewServiceKillStartEvent, events.NewServiceKillDoneEvent, events.NewServiceKillFailedEvent)
+		wrapper.Do(nil, serviceEventWrapper, func(service Service) error {
 			return service.Kill(ctx, signal)
 		})
 	}), nil)

--- a/project/project_log.go
+++ b/project/project_log.go
@@ -9,7 +9,7 @@ import (
 // Log aggregates and prints out the logs for the specified services.
 func (p *Project) Log(ctx context.Context, follow bool, services ...string) error {
 	return p.forEach(services, wrapperAction(func(wrapper *serviceWrapper, wrappers map[string]*serviceWrapper) {
-		wrapper.Do(nil, events.NoEvent, events.NoEvent, func(service Service) error {
+		wrapper.Do(nil, events.NewDummyEventWrapper("Log"), func(service Service) error {
 			return service.Log(ctx, follow)
 		})
 	}), nil)

--- a/project/project_pause.go
+++ b/project/project_pause.go
@@ -8,8 +8,10 @@ import (
 
 // Pause pauses the specified services containers (like docker pause).
 func (p *Project) Pause(ctx context.Context, services ...string) error {
-	return p.perform(events.ProjectPauseStart, events.ProjectPauseDone, services, wrapperAction(func(wrapper *serviceWrapper, wrappers map[string]*serviceWrapper) {
-		wrapper.Do(nil, events.ServicePauseStart, events.ServicePause, func(service Service) error {
+	eventWrapper := events.NewEventWrapper("Project Pause", events.NewProjectPauseStartEvent, events.NewProjectPauseDoneEvent, events.NewProjectPauseFailedEvent)
+	return p.perform(eventWrapper, services, wrapperAction(func(wrapper *serviceWrapper, wrappers map[string]*serviceWrapper) {
+		serviceEventWrapper := events.NewEventWrapper("Service Pause", events.NewServicePauseStartEvent, events.NewServicePauseDoneEvent, events.NewServicePauseFailedEvent)
+		wrapper.Do(nil, serviceEventWrapper, func(service Service) error {
 			return service.Pause(ctx)
 		})
 	}), nil)

--- a/project/project_pull.go
+++ b/project/project_pull.go
@@ -9,7 +9,8 @@ import (
 // Pull pulls the specified services (like docker pull).
 func (p *Project) Pull(ctx context.Context, services ...string) error {
 	return p.forEach(services, wrapperAction(func(wrapper *serviceWrapper, wrappers map[string]*serviceWrapper) {
-		wrapper.Do(nil, events.ServicePullStart, events.ServicePull, func(service Service) error {
+		serviceEventWrapper := events.NewEventWrapper("Service Pull", events.NewServicePullStartEvent, events.NewServicePullDoneEvent, events.NewServicePullFailedEvent)
+		wrapper.Do(nil, serviceEventWrapper, func(service Service) error {
 			return service.Pull(ctx)
 		})
 	}), nil)

--- a/project/project_restart.go
+++ b/project/project_restart.go
@@ -8,8 +8,10 @@ import (
 
 // Restart restarts the specified services (like docker restart).
 func (p *Project) Restart(ctx context.Context, timeout int, services ...string) error {
-	return p.perform(events.ProjectRestartStart, events.ProjectRestartDone, services, wrapperAction(func(wrapper *serviceWrapper, wrappers map[string]*serviceWrapper) {
-		wrapper.Do(wrappers, events.ServiceRestartStart, events.ServiceRestart, func(service Service) error {
+	eventWrapper := events.NewEventWrapper("Project Restart", events.NewProjectRestartStartEvent, events.NewProjectRestartDoneEvent, events.NewProjectRestartFailedEvent)
+	return p.perform(eventWrapper, services, wrapperAction(func(wrapper *serviceWrapper, wrappers map[string]*serviceWrapper) {
+		serviceEventWrapper := events.NewEventWrapper("Service Restart", events.NewServiceRestartStartEvent, events.NewServiceRestartDoneEvent, events.NewServiceRestartFailedEvent)
+		wrapper.Do(wrappers, serviceEventWrapper, func(service Service) error {
 			return service.Restart(ctx, timeout)
 		})
 	}), nil)

--- a/project/project_run.go
+++ b/project/project_run.go
@@ -20,7 +20,8 @@ func (p *Project) Run(ctx context.Context, serviceName string, commandParts []st
 	}
 	var exitCode int
 	err := p.forEach([]string{}, wrapperAction(func(wrapper *serviceWrapper, wrappers map[string]*serviceWrapper) {
-		wrapper.Do(wrappers, events.ServiceRunStart, events.ServiceRun, func(service Service) error {
+		serviceEventWrapper := events.NewEventWrapper("Service Run", events.NewServiceRunStartEvent, events.NewServiceRunDoneEvent, events.NewServiceRunFailedEvent)
+		wrapper.Do(wrappers, serviceEventWrapper, func(service Service) error {
 			if service.Name() == serviceName {
 				code, err := service.Run(ctx, commandParts, opts)
 				exitCode = code

--- a/project/project_start.go
+++ b/project/project_start.go
@@ -8,8 +8,10 @@ import (
 
 // Start starts the specified services (like docker start).
 func (p *Project) Start(ctx context.Context, services ...string) error {
-	return p.perform(events.ProjectStartStart, events.ProjectStartDone, services, wrapperAction(func(wrapper *serviceWrapper, wrappers map[string]*serviceWrapper) {
-		wrapper.Do(wrappers, events.ServiceStartStart, events.ServiceStart, func(service Service) error {
+	eventWrapper := events.NewEventWrapper("Project Start", events.NewProjectStartStartEvent, events.NewProjectStartDoneEvent, events.NewProjectStartFailedEvent)
+	return p.perform(eventWrapper, services, wrapperAction(func(wrapper *serviceWrapper, wrappers map[string]*serviceWrapper) {
+		serviceEventWrapper := events.NewEventWrapper("Project Start", events.NewServiceStartStartEvent, events.NewServiceStartDoneEvent, events.NewServiceStartFailedEvent)
+		wrapper.Do(wrappers, serviceEventWrapper, func(service Service) error {
 			return service.Start(ctx)
 		})
 	}), nil)

--- a/project/project_stop.go
+++ b/project/project_stop.go
@@ -8,8 +8,10 @@ import (
 
 // Stop stops the specified services (like docker stop).
 func (p *Project) Stop(ctx context.Context, timeout int, services ...string) error {
-	return p.perform(events.ProjectStopStart, events.ProjectStopDone, services, wrapperAction(func(wrapper *serviceWrapper, wrappers map[string]*serviceWrapper) {
-		wrapper.Do(nil, events.ServiceStopStart, events.ServiceStop, func(service Service) error {
+	eventWrapper := events.NewEventWrapper("Project Stop", events.NewProjectStopStartEvent, events.NewProjectStopDoneEvent, events.NewProjectStopFailedEvent)
+	return p.perform(eventWrapper, services, wrapperAction(func(wrapper *serviceWrapper, wrappers map[string]*serviceWrapper) {
+		serviceEventWrapper := events.NewEventWrapper("Service Stop", events.NewServiceStopStartEvent, events.NewServiceStopDoneEvent, events.NewServiceStopFailedEvent)
+		wrapper.Do(nil, serviceEventWrapper, func(service Service) error {
 			return service.Stop(ctx, timeout)
 		})
 	}), nil)

--- a/project/project_unpause.go
+++ b/project/project_unpause.go
@@ -8,8 +8,10 @@ import (
 
 // Unpause pauses the specified services containers (like docker pause).
 func (p *Project) Unpause(ctx context.Context, services ...string) error {
-	return p.perform(events.ProjectUnpauseStart, events.ProjectUnpauseDone, services, wrapperAction(func(wrapper *serviceWrapper, wrappers map[string]*serviceWrapper) {
-		wrapper.Do(nil, events.ServiceUnpauseStart, events.ServiceUnpause, func(service Service) error {
+	eventWrapper := events.NewEventWrapper("Project Pause", events.NewProjectUnpauseStartEvent, events.NewProjectUnpauseDoneEvent, events.NewProjectUnpauseFailedEvent)
+	return p.perform(eventWrapper, services, wrapperAction(func(wrapper *serviceWrapper, wrappers map[string]*serviceWrapper) {
+		serviceEventWrapper := events.NewEventWrapper("Service Pause", events.NewServiceUnpauseStartEvent, events.NewServiceUnpauseDoneEvent, events.NewServiceUnpauseFailedEvent)
+		wrapper.Do(nil, serviceEventWrapper, func(service Service) error {
 			return service.Unpause(ctx)
 		})
 	}), nil)

--- a/project/project_up.go
+++ b/project/project_up.go
@@ -8,12 +8,15 @@ import (
 )
 
 // Up creates and starts the specified services (kinda like docker run).
+// Up creates and starts the specified services (kinda like docker run).
 func (p *Project) Up(ctx context.Context, options options.Up, services ...string) error {
 	if err := p.initialize(ctx); err != nil {
 		return err
 	}
-	return p.perform(events.ProjectUpStart, events.ProjectUpDone, services, wrapperAction(func(wrapper *serviceWrapper, wrappers map[string]*serviceWrapper) {
-		wrapper.Do(wrappers, events.ServiceUpStart, events.ServiceUp, func(service Service) error {
+	eventWrapper := events.NewEventWrapper("Project Up", events.NewProjectUpStartEvent, events.NewProjectUpDoneEvent, events.NewProjectUpFailedEvent)
+	return p.perform(eventWrapper, services, wrapperAction(func(wrapper *serviceWrapper, wrappers map[string]*serviceWrapper) {
+		serviceEventWrapper := events.NewEventWrapper("Service Up", events.NewServiceUpStartEvent, events.NewServiceUpDoneEvent, events.NewServiceUpFailedEvent)
+		wrapper.Do(wrappers, serviceEventWrapper, func(service Service) error {
 			return service.Up(ctx, options)
 		})
 	}), func(service Service) error {


### PR DESCRIPTION
Porting https://github.com/docker/libcompose/pull/347 to this project

@bfosberry can you verify that the PR is complete and ready for review?

This change updates all project, service and container events to be heavily typed,
which allows event readers to expect specific fields rather than reading from an
attribute map

The main point of this change is that instead of using an event code enum, this now uses strict struct types. This allows select type-casting on the event read side, and as a result users can expect specific structures with clear fields and functions instead of having to look up specific values which may or may not be in the map and may or may not be valid as blank.

The downside of this approach is that it is very explicit and a lot of structs are generated. There is also some field misuse (project events have an un-used serviceName field), however the alternative for this would be to have two sets of interfaces for generating events (factory and wrapper)

To fit with the project/project and docker/service way of creating events en-masse, this ships with EventFactory (creates on-demand events for a specified service name) and EventWrapper (creates started/created/done events depending on if the action succeeded). This allow the struct typing to fit better into the more meta-approach of bulk-service actions using wrappers.